### PR TITLE
fix: Histogram 차트의 selectbox 이벤트를 props로 받을수 있도록 합니다

### DIFF
--- a/src/components/__tests__/Histogram.test.js
+++ b/src/components/__tests__/Histogram.test.js
@@ -70,4 +70,21 @@ describe('Histogram Component', () => {
     expect(instance.yAxis.tickValues()).toEqual([1, 10, 100, 1000, 10000, 40000])
     expect(instance.gridXAxis.tickValues()).toEqual([1, 10, 100, 1000, 10000, 40000])
   })
+
+  it('onChage 함수를 props로 받으면, selectbox를 선택할 때, onChange가 호출되어야 한다.', () => {
+    const onChange = jest.fn()
+    component.setProps({
+      onChange,
+    })
+
+    component.find('select').simulate('change', {
+      target: {
+        value: 20,
+      },
+    })
+
+    component.update()
+
+    expect(onChange).toHaveBeenCalled()
+  })
 })

--- a/src/components/charts/Histogram.js
+++ b/src/components/charts/Histogram.js
@@ -349,7 +349,7 @@ Histogram.defaultProps = {
   yMaxValue: undefined,
   chartWidth: undefined,
   chartHeight: undefined,
-  onChange: undefined,
+  onChange: () => {},
 }
 
 Histogram.propTypes = {

--- a/src/components/charts/Histogram.js
+++ b/src/components/charts/Histogram.js
@@ -302,7 +302,7 @@ class Histogram extends Component {
   }
 
   onChangeHistogram = ({ target: { value } }) => {
-    const { data } = this.props
+    const { data, onChange } = this.props
 
     this.getRootElement().select('.gBar')
       .remove()
@@ -313,6 +313,7 @@ class Histogram extends Component {
 
     this.createBar(data, value)
     this.createRiskMeanLine(data)
+    onChange(value)
   }
 
   render() {
@@ -348,6 +349,7 @@ Histogram.defaultProps = {
   yMaxValue: undefined,
   chartWidth: undefined,
   chartHeight: undefined,
+  onChange: undefined,
 }
 
 Histogram.propTypes = {
@@ -355,6 +357,7 @@ Histogram.propTypes = {
   yMaxValue: PropTypes.number,
   chartWidth: PropTypes.number,
   chartHeight: PropTypes.number,
+  onChange: PropTypes.func,
 }
 
 export default Histogram

--- a/src/components/charts/Histogram.md
+++ b/src/components/charts/Histogram.md
@@ -2,8 +2,6 @@ Histogram example:
 
 ```js
   <Histogram
-    title='histogram title'
-    tooltipTitle='I.I.T Risk Score'
     data={{
       avgRisk: 0.34,
       patientRisk: 0.45,
@@ -18,7 +16,7 @@ Histogram example:
         0.81, 0.82,
         0.9
       ]
-    }
-    }
+    }}
+    onChange={(value) => alert(value)}
   />
 ```


### PR DESCRIPTION
1. onChange를 props로 받을수 있도록 변경
2. onChagne가 호출되는지 테스트 추가
3. styleguide 변경

close: #496

## 중요 : 먼저 이슈를 생성하지 않고 풀 요청을 생성하지 마십시오.
다른 사람들이 풀 요청을 검토 할 수 있도록 충분한 정보를 제공해주세요

## 테스트
- [ ] 테스트가 local CLI, Travis 모두 통과하는지 확인

## 해결 issue
closes: #496 

PR에서 해결하는 문제 (있는 경우)를 자동으로 닫으려면 주석에 #xxxx 이슈 번호를 기입
