### PR TITLE
feat: Histogram 차트의 onChange event에 인자를 하나 더 추가합니다

### DIFF
--- a/src/components/__tests__/Histogram.test.js
+++ b/src/components/__tests__/Histogram.test.js
@@ -87,4 +87,22 @@ describe('Histogram Component', () => {
 
     expect(onChange).toHaveBeenCalled()
   })
+
+  it('selectbox onChange 이벤트가 발생할 때, selectbox value와 bins 데이터를 인자로 받습니다.', () => {
+    const onChange = jest.fn()
+    const expectedValue = instance.createHistogramData(data.risks, 20)
+    component.setProps({
+      onChange,
+    })
+
+    component.find('select').simulate('change', {
+      target: {
+        value: 20,
+      },
+    })
+
+    component.update()
+
+    expect(onChange).toHaveBeenCalledWith(20, expectedValue)
+  })
 })

--- a/src/components/charts/Histogram.md
+++ b/src/components/charts/Histogram.md
@@ -17,6 +17,6 @@ Histogram example:
         0.9
       ]
     }}
-    onChange={(value) => alert(value)}
+    onChange={(value, binsList) => alert(value)}
   />
 ```


### PR DESCRIPTION

1. histogramData를 만드는 함수 추가
2. onChange event에 histogramData를 인자로 추가
3. Histogram을 부모에서 onChange 이벤트 정보를 감지하기위한 initOnChangeFlag 추가
4. onChange 이벤트 발생할때, onChange 인자 테스트 추가

closes: #503

## 중요 : 먼저 이슈를 생성하지 않고 풀 요청을 생성하지 마십시오.
다른 사람들이 풀 요청을 검토 할 수 있도록 충분한 정보를 제공해주세요

## 테스트
- [ ] 테스트가 local CLI, Travis 모두 통과하는지 확인

## 해결 issue
closes: #503 

PR에서 해결하는 문제 (있는 경우)를 자동으로 닫으려면 주석에 #xxxx 이슈 번호를 기입
