### PR TITLE
feat: SummaryCard에서 events가 있으면 hover효과 추가, box-shadow 변경

### DIFF
--- a/src/components/card/SummaryCard.js
+++ b/src/components/card/SummaryCard.js
@@ -12,12 +12,10 @@ const Wrap1200 = styled.div`
 `
 
 const hover = css`
-  bottom: 0;
-  transition: bottom 0.1s ease-in-out;
+  transition: transform 0.1s ease-in-out;
   &:hover {
-    position: relative;
     box-shadow: 0 8px 40px 0 rgba(117, 127, 139, 0.2);
-    bottom: 4px;
+    transform: translateY(-4px);
   }
 `
 

--- a/src/components/card/SummaryCard.js
+++ b/src/components/card/SummaryCard.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import PropTypes from 'prop-types'
 import fontStyle from '@src/assets/styles/font.module.sass'
 
@@ -11,11 +11,21 @@ const Wrap1200 = styled.div`
   margin: 0 auto
 `
 
+const hover = css`
+  bottom: 0;
+  transition: bottom 0.1s ease-in-out;
+  &:hover {
+    position: relative;
+    box-shadow: 0 8px 40px 0 rgba(117, 127, 139, 0.2);
+    bottom: 4px;
+  }
+`
+
 export const Article = styled.article`
   width: 282px;
   height: 160px;
   border-radius: 8px;
-  box-shadow: 0 1px 8px 0 rgb(117, 127, 139);
+  box-shadow: 0 1px 8px 0 rgba(117, 127, 139, 0.36);
   background-color: #ffffff;
   font-size: 0;
   display: inline-block;
@@ -33,6 +43,11 @@ export const Article = styled.article`
 
     margin: 0;
   }
+
+  ${(props) => {
+    if (props.events) return hover
+    return null
+  }}
 `
 
 export const EventElement = styled.div`
@@ -66,7 +81,7 @@ const SummaryCard = ({ className, data, events }) => {
       {summaryData.map(([name, value], idx) => {
         const key = `SummaryCard${idx}`
         return (
-          <Article key={key} className={className}>
+          <Article key={key} className={className} events={events[name]}>
             <EventElement onClick={events[name] ? () => { events[name]() } : null}>
               <dl>
                 <DD>{value}</DD>


### PR DESCRIPTION
1. 시안에 맞춰서 box-shadow 변경
2. events가 있을 때, SummaryCard에 hover 효과 추가

## 중요 : 먼저 이슈를 생성하지 않고 풀 요청을 생성하지 마십시오.
다른 사람들이 풀 요청을 검토 할 수 있도록 충분한 정보를 제공해주세요

## 테스트
- [x] 테스트가 local CLI, Travis 모두 통과하는지 확인

## 해결 issue
closes: #571
