### PR TITLE
improvement: index에 tableProperties를 export에 추가

### DIFF
--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -24,7 +24,7 @@ const includeModule = [
   'ToggleButton', 'TooltipBox',
   'TreeMap', 'chartUtility',
   'commonTag', 'font',
-  'variables', 'notifications', 'ChartColor',
+  'variables', 'tableProperties', 'notifications', 'ChartColor',
 ]
 
 it('include module', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,7 @@ import * as commonTag from '@Components/common/commonTag'
 import SelectBox from '@Components/form/SelectBox'
 import * as font from '@src/assets/styles/font'
 import * as variables from '@src/assets/styles/variables'
+import * as tableProperties from '@src/assets/styles/tableProperties'
 import * as chartUtility from '@src/helper/chartUtility'
 
 import * as DateUtility from '@src/helper/DateUtility'
@@ -75,6 +76,7 @@ export {
   RadioBox,
   font,
   variables,
+  tableProperties,
   chartUtility,
   Button,
   ButtonLink,


### PR DESCRIPTION
## 중요 : 먼저 이슈를 생성하지 않고 풀 요청을 생성하지 마십시오.
다른 사람들이 풀 요청을 검토 할 수 있도록 충분한 정보를 제공해주세요
index에서 tableProperties를 export하여 프로젝트에서 table을 custom하는 과정에서 수치를 재활용하여 사용할 수 있도록 합니다.

## 테스트
- [ ] 테스트가 local CLI, Travis 모두 통과하는지 확인

## 해결 issue
closes: #649 

PR에서 해결하는 문제 (있는 경우)를 자동으로 닫으려면 주석에 #xxxx 이슈 번호를 기입
