### PR TITLE
fix(LineMergedTimeline): 차트 컬러셋 순서 변경

### DIFF
--- a/src/components/charts/LineMergeTimeline.js
+++ b/src/components/charts/LineMergeTimeline.js
@@ -435,11 +435,11 @@ class LineMergeTimeline extends Component {
     } = this.options
 
     const rectColorList = _.map(
-      ['teal400', 'rose200', 'sea600', 'bluegrey300', 'bluegrey230', 'bluegrey170', 'bluegrey120', 'bluegrey80', 'bluegrey50'],
+      ['teal400', 'sea600', 'rose200', 'bluegrey300', 'bluegrey230', 'bluegrey170', 'bluegrey120', 'bluegrey80', 'bluegrey50'],
       (name) => ColorSetMap[name],
     )
 
-    const circleColorList = _.map(['teal600', 'rose200', 'sea600'], (name) => ColorSetMap[name])
+    const circleColorList = _.map(['teal600', 'sea600', 'rose200'], (name) => ColorSetMap[name])
 
     // Create Timeline Chart
     const circleColorScale = d3.scaleOrdinal()
@@ -476,7 +476,7 @@ class LineMergeTimeline extends Component {
           const tooltip = this.getRootElement().select(`.${styles.tooltip}`)
           const tooltipDescription = `
             <div>
-              <div class=${styles.tooltipLabel}><span class=${styles.dot}></span> ${label}</div>
+              <div class=${styles.tooltipLabel}><span class=${styles.dot} style="background-color: ${rectColorScale(data.label[data.label.length - 1])};"></span> ${label}</div>
               <div class=${styles.tooltipDay}>${d3.timeFormat('%Y.%m.%d')(new Date(d.startTime))} ~ ${d3.timeFormat('%Y.%m.%d')(new Date(d.endTime))}</div>
             </div>
             `
@@ -513,7 +513,7 @@ class LineMergeTimeline extends Component {
           const tooltip = this.getRootElement().select(`.${styles.tooltip}`)
           const tooltipDescription = `
             <div>
-              <div class=${styles.tooltipLabel}><span class=${styles.dot}></span> ${label}</div>
+              <div class=${styles.tooltipLabel}><span class=${styles.dot} style="background-color: ${circleColorScale(data.label[data.label.length - 1])};"></span> ${label}</div>
               <div class=${styles.tooltipDay}>${d3.timeFormat('%Y.%m.%d')(new Date(d.startTime))} ~ ${d3.timeFormat('%Y.%m.%d')(new Date(d.endTime))}</div>
             </div>
             `


### PR DESCRIPTION
1. renderTimeLineChart에서 colorList 순서 변경
2. tooltip에 컬러셋에 맞도록 background style 추가

closes: #678

## 중요 : 먼저 이슈를 생성하지 않고 풀 요청을 생성하지 마십시오.
다른 사람들이 풀 요청을 검토 할 수 있도록 충분한 정보를 제공해주세요

## 테스트
- [ ] 테스트가 local CLI, Travis 모두 통과하는지 확인

## 해결 issue
closes: #678

PR에서 해결하는 문제 (있는 경우)를 자동으로 닫으려면 주석에 #xxxx 이슈 번호를 기입
