### PR TITLE
chore: revert recharts 2.x.x -> 1.8.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "react-custom-scrollbars": "^4.2.1",
     "react-dom": "^16.9.0",
     "react-transition-group": "^4.3.0",
-    "recharts": "^2.1.6",
+    "recharts": "1.8.5",
     "regenerator-runtime": "^0.13.7",
     "styled-components": "^4.3.2",
     "tslib": "^2.3.1",


### PR DESCRIPTION
chore: revert recharts 2.x.x -> 1.8.5

기존에 사용하는 곳에서 recharts 2.1.3 이상 버전 사용 시 es module 미지원으로 인한 에러로 인한 버전 다운